### PR TITLE
Added logic to ignore unknown packages for dependencies

### DIFF
--- a/src/reading.ts
+++ b/src/reading.ts
@@ -28,9 +28,15 @@ export async function getAllPackageDependencies(
     packagePaths: Map<string, string>,
     fileReader: IFileReader): Promise<Map<string, Set<string>>> {
     const packageDependencies = new Map<string, Set<string>>();
+    const packageNames = new Set(packagePaths.keys()) ;
 
     for (const [packageName, packagePath] of packagePaths) {
-        packageDependencies.set(packageName, await getPackageDependencies(packagePath, fileReader));
+        const dependencies = await getPackageDependencies(packagePath, fileReader);
+        const knownDependencies = new Set(
+            Array.from(dependencies)
+                .filter(dependency => packageNames.has(dependency)));
+
+        packageDependencies.set(packageName, knownDependencies);
     }
 
     return packageDependencies;

--- a/test/fakes.ts
+++ b/test/fakes.ts
@@ -1,14 +1,19 @@
 import * as path from "path";
 
 export const DEPENDENT = "dependent";
+export const EXTERNAL = "external";
 export const SINGLE = "single";
 export const SOLO = "solo";
+export const UNKNOWN = "unknown";
 
-export type IPackageName = typeof DEPENDENT | typeof SINGLE | typeof SOLO;
+export type IPackageName = typeof DEPENDENT | typeof EXTERNAL | typeof SINGLE | typeof SOLO;
 
 const stubPackageContents = {
     [path.join(DEPENDENT, ".json")]: JSON.stringify({
         dependencies: [SINGLE],
+    }),
+    [path.join(EXTERNAL, ".json")]: JSON.stringify({
+        dependencies: [SINGLE, UNKNOWN],
     }),
     [path.join(SINGLE, ".json")]: JSON.stringify({}),
     [path.join(SOLO, ".json")]: JSON.stringify({}),

--- a/test/parallel.ts
+++ b/test/parallel.ts
@@ -2,7 +2,7 @@ import { expect } from "chai";
 
 import { getBuildTracker } from "../lib/parallel";
 import { ParallelBuildTracker } from "../lib/parallel/parallelBuildTracker";
-import { DEPENDENT, fileReader, IPackageName, mockPathSettings, SINGLE, SOLO } from "./fakes";
+import { DEPENDENT, EXTERNAL, fileReader, IPackageName, mockPathSettings, SINGLE, SOLO } from "./fakes";
 
 /**
  * Creates a build tracker pointing to the stubbed packages.
@@ -74,6 +74,17 @@ describe("ParallelBuildTracker", () => {
 
             // Assert
             expect(availablePackages).to.be.deep.equal([DEPENDENT]);
+        });
+
+        it("ignores unknown packages", async () => {
+            // Arrange
+            const tracker = await mockBuildTracker(SINGLE, EXTERNAL);
+
+            // Act
+            const availablePackages = tracker.markCompleted(SINGLE);
+
+            // Assert
+            expect(availablePackages).to.be.deep.equal([EXTERNAL]);
         });
 
         it("returns a blank array when done", async () => {


### PR DESCRIPTION
If a listed dependency isn't in the known paths mapping, it shouldn't be accounted for during orders.