### PR TITLE
Add support for optional and peer dependencies

### DIFF
--- a/src/parallel.ts
+++ b/src/parallel.ts
@@ -1,32 +1,6 @@
-import { normalizePackagePaths, PackagePaths } from "./packages";
 import { ParallelBuildTracker } from "./parallel/parallelBuildTracker";
-import { readFileWithoutBom } from "./readFileWithoutBom";
-import { getAllPackageDependencies, IFileReader } from "./reading";
-
-/**
- * Settings to get a build tracker.
- */
-export interface IBuildTrackerSettings {
-    /**
-     * Reads file contents.
-     */
-    fileReader?: IFileReader;
-
-    /**
-     * When reading dependencies, also check optionalDependencies
-     */
-    includeOptionalDependencies?: boolean;
-
-    /**
-     * When reading dependencies, also check peerDependencies
-     */
-    includePeerDependencies?: boolean;
-
-    /**
-     * Package paths, keyed by package name.
-     */
-    paths: PackagePaths;
-}
+import { getAllPackageDependencies } from "./reading";
+import { ISettings, normalizeSettings } from "./settings";
 
 /**
  * Creates a tracker for newly buildable packages given completed dependencies.
@@ -34,21 +8,9 @@ export interface IBuildTrackerSettings {
  * @param settings   Settings to get a build tracker.
  * @returns A Promise for a package build tracker.
  */
-export async function getBuildTracker(settings: IBuildTrackerSettings): Promise<ParallelBuildTracker> {
-    const normalizedSettings = {
-        fileReader: (async (filePath: string) => (await readFileWithoutBom(filePath)).toString()),
-        includeOptionalDependencies: false,
-        includePeerDependencies: false,
-        ...settings,
-    };
-
-    const packagePaths = normalizePackagePaths(settings.paths);
-
-    const dependencies = await getAllPackageDependencies(
-        packagePaths,
-        normalizedSettings.fileReader,
-        normalizedSettings.includeOptionalDependencies,
-        normalizedSettings.includePeerDependencies);
+export async function getBuildTracker(settings: ISettings): Promise<ParallelBuildTracker> {
+    const normalizedSettings = normalizeSettings(settings);
+    const dependencies = await getAllPackageDependencies(normalizedSettings);
 
     return new ParallelBuildTracker(dependencies);
 }

--- a/src/reading.ts
+++ b/src/reading.ts
@@ -1,11 +1,26 @@
 import * as path from "path";
 import * as stripJsonComments from "strip-json-comments";
+import { IExcludedDependenciesSettings, IFileReaderSettings } from "./settings";
 
 interface IPackageInfo {
     dependencies?: string[] | Record<string, string>;
     devDependencies?: string[] | Record<string, string>;
     optionalDependencies?: string[] | Record<string, string>;
     peerDependencies?: string[] | Record<string, string>;
+}
+
+export interface IGetAllPackageDependenciesOptions extends IFileReaderSettings, IExcludedDependenciesSettings {
+    /**
+     * Package paths, keyed by package name.
+     */
+    paths: Map<string, string>;
+}
+
+interface IGetPackageDependenciesOptions extends IFileReaderSettings, IExcludedDependenciesSettings {
+    /**
+     * Path to a package file.
+     */
+    packagePath: string;
 }
 
 /**
@@ -23,21 +38,16 @@ export type IFileReader = (filePath: string) => Promise<string>;
  * @param fileReader   Reads file contents.
  * @returns A Promise for packages with their dependencies.
  */
-export async function getAllPackageDependencies(
-    packagePaths: Map<string, string>,
-    fileReader: IFileReader,
-    includeOptionalDependencies: boolean,
-    includePeerDependencies: boolean,
+export async function getAllPackageDependencies(options: IGetAllPackageDependenciesOptions,
 ): Promise<Map<string, Set<string>>> {
     const packageDependencies = new Map<string, Set<string>>();
-    const packageNames = new Set(packagePaths.keys()) ;
+    const packageNames = new Set(options.paths.keys()) ;
 
-    for (const [packageName, packagePath] of packagePaths) {
-        const dependencies = await getPackageDependencies(
+    for (const [packageName, packagePath] of options.paths) {
+        const dependencies = await getPackageDependencies({
             packagePath,
-            fileReader,
-            includeOptionalDependencies,
-            includePeerDependencies);
+            ...options,
+        });
 
         const knownDependencies = new Set(
             Array.from(dependencies)
@@ -52,28 +62,22 @@ export async function getAllPackageDependencies(
 /**
  * Retrieves dependencies for a package.
  *
- * @param packagePath   Path to a package file.
- * @param fileReader   Reads file contents.
+ * @param options
  * @returns A Promise for the package's dependencies.
  */
-async function getPackageDependencies(
-    packagePath: string,
-    fileReader: IFileReader,
-    includeOptionalDependencies: boolean,
-    includePeerDependencies: boolean,
-): Promise<Set<string>> {
+async function getPackageDependencies(options: IGetPackageDependenciesOptions): Promise<Set<string>> {
     const {
         dependencies,
         devDependencies,
         optionalDependencies,
         peerDependencies,
-    } = await getPackageContents(packagePath, fileReader);
+    } = await getPackageContents(options.packagePath, options.fileReader);
 
     return new Set([
         ...flatten(dependencies),
-        ...flatten(devDependencies),
-        ...flatten(includeOptionalDependencies ? optionalDependencies : []),
-        ...flatten(includePeerDependencies ? peerDependencies : []),
+        ...flatten(options.excludeDevDependencies ? [] : devDependencies),
+        ...flatten(options.excludeOptionalDependencies ? [] : optionalDependencies),
+        ...flatten(options.excludePeerDependencies ? [] : peerDependencies),
     ]);
 }
 

--- a/src/series.ts
+++ b/src/series.ts
@@ -1,32 +1,6 @@
-import { normalizePackagePaths, PackagePaths } from "./packages";
-import { readFileWithoutBom } from "./readFileWithoutBom";
-import { getAllPackageDependencies, IFileReader } from "./reading";
+import { getAllPackageDependencies } from "./reading";
+import { ISettings, normalizeSettings } from "./settings";
 import { sortPackages } from "./sorting";
-
-/**
- * Settings to sort packages into a safe build order.
- */
-export interface IBuildOrderSettings {
-    /**
-     * Reads file contents.
-     */
-    fileReader?: IFileReader;
-
-    /**
-     * When reading dependencies, also check optionalDependencies
-     */
-    includeOptionalDependencies?: boolean;
-
-    /**
-     * When reading dependencies, also check peerDependencies
-     */
-    includePeerDependencies?: boolean;
-
-    /**
-     * Package paths, keyed by package name.
-     */
-    paths: PackagePaths;
-}
 
 /**
  * Sorts packages into a safe build order.
@@ -34,21 +8,9 @@ export interface IBuildOrderSettings {
  * @param settings   Settings to sort packages into a safe build order.
  * @returns A Promise for the packages in a safe build order.
  */
-export async function buildOrder(settings: IBuildOrderSettings): Promise<string[]> {
-    const normalizedSettings = {
-        fileReader: (async (filePath: string) => (await readFileWithoutBom(filePath)).toString()),
-        includeOptionalDependencies: false,
-        includePeerDependencies: false,
-        ...settings,
-    };
-
-    const packagePaths = normalizePackagePaths(settings.paths);
-
-    const dependencies = await getAllPackageDependencies(
-        packagePaths,
-        normalizedSettings.fileReader,
-        normalizedSettings.includeOptionalDependencies,
-        normalizedSettings.includePeerDependencies);
+export async function buildOrder(settings: ISettings): Promise<string[]> {
+    const normalizedSettings = normalizeSettings(settings);
+    const dependencies = await getAllPackageDependencies(normalizedSettings);
 
     return sortPackages(dependencies);
 }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,0 +1,52 @@
+import { normalizePackagePaths, PackagePaths } from "./packages";
+import { readFileWithoutBom } from "./readFileWithoutBom";
+import { IFileReader } from "./reading";
+
+export interface IExcludedDependenciesSettings {
+    /**
+     * When reading dependencies, exclude devDependencies
+     */
+    excludeDevDependencies: boolean;
+
+    /**
+     * When reading dependencies, exclude optionalDependencies
+     */
+    excludeOptionalDependencies: boolean;
+
+    /**
+     * When reading dependencies, exclude peerDependencies
+     */
+    excludePeerDependencies: boolean;
+}
+
+export interface IFileReaderSettings {
+   /**
+    * Reads file contents.
+    */
+   fileReader: IFileReader;
+}
+
+/**
+ * Settings to sort packages into a safe build order.
+ */
+export interface ISettings extends Partial<IFileReaderSettings>, Partial<IExcludedDependenciesSettings> {
+    /**
+     * Package paths, keyed by package name.
+     */
+    paths: PackagePaths;
+}
+
+/**
+ * normalizes settings
+ * @param settings Settings to normalize
+ */
+export function normalizeSettings(settings: ISettings) {
+    return {
+        excludeDevDependencies: false,
+        excludeOptionalDependencies: false,
+        excludePeerDependencies: false,
+        fileReader: (async (filePath: string) => (await readFileWithoutBom(filePath)).toString()),
+        ...settings,
+        paths: normalizePackagePaths(settings.paths),
+    };
+}

--- a/test/fakes.ts
+++ b/test/fakes.ts
@@ -1,20 +1,36 @@
 import * as path from "path";
 
 export const DEPENDENT = "dependent";
+export const DEV = "dev";
 export const EXTERNAL = "external";
+export const OPTIONAL = "optional";
+export const PEER = "peer";
 export const SINGLE = "single";
 export const SOLO = "solo";
 export const UNKNOWN = "unknown";
 
-export type IPackageName = typeof DEPENDENT | typeof EXTERNAL | typeof SINGLE | typeof SOLO;
+export type IPackageName =
+    typeof DEPENDENT |
+    typeof DEV |
+    typeof EXTERNAL |
+    typeof OPTIONAL |
+    typeof PEER |
+    typeof SINGLE |
+    typeof SOLO;
 
 const stubPackageContents = {
     [path.join(DEPENDENT, ".json")]: JSON.stringify({
         dependencies: [SINGLE],
+        devDependencies: [DEV],
+        optionalDependencies: [OPTIONAL],
+        peerDependencies: [PEER],
     }),
+    [path.join(DEV, ".json")]: JSON.stringify({}),
     [path.join(EXTERNAL, ".json")]: JSON.stringify({
         dependencies: [SINGLE, UNKNOWN],
     }),
+    [path.join(OPTIONAL, ".json")]: JSON.stringify({}),
+    [path.join(PEER, ".json")]: JSON.stringify({}),
     [path.join(SINGLE, ".json")]: JSON.stringify({}),
     [path.join(SOLO, ".json")]: JSON.stringify({}),
 };

--- a/test/parallel.ts
+++ b/test/parallel.ts
@@ -2,7 +2,18 @@ import { expect } from "chai";
 
 import { getBuildTracker } from "../lib/parallel";
 import { ParallelBuildTracker } from "../lib/parallel/parallelBuildTracker";
-import { DEPENDENT, EXTERNAL, fileReader, IPackageName, mockPathSettings, SINGLE, SOLO } from "./fakes";
+import {
+    DEPENDENT,
+    DEV,
+    EXTERNAL,
+    fileReader,
+    IPackageName,
+    mockPathSettings,
+    OPTIONAL,
+    PEER,
+    SINGLE,
+    SOLO,
+} from "./fakes";
 
 /**
  * Creates a build tracker pointing to the stubbed packages.
@@ -49,6 +60,39 @@ describe("ParallelBuildTracker", () => {
 
             // Assert
             expect(availablePackages).to.be.deep.equal([SINGLE]);
+        });
+
+        it("gives only available initial packages when some have dev dependencies ", async () => {
+            // Arrange
+            const tracker = await mockBuildTracker(DEPENDENT, DEV);
+
+            // Act
+            const availablePackages = tracker.getAvailablePackages();
+
+            // Assert
+            expect(availablePackages).to.be.deep.equal([DEV]);
+        });
+
+        it("gives only available initial packages when some have peer dependencies ", async () => {
+            // Arrange
+            const tracker = await mockBuildTracker(DEPENDENT, PEER);
+
+            // Act
+            const availablePackages = tracker.getAvailablePackages();
+
+            // Assert
+            expect(availablePackages).to.be.deep.equal([PEER]);
+        });
+
+        it("gives only available initial packages when some have optional dependencies ", async () => {
+            // Arrange
+            const tracker = await mockBuildTracker(DEPENDENT, OPTIONAL);
+
+            // Act
+            const availablePackages = tracker.getAvailablePackages();
+
+            // Assert
+            expect(availablePackages).to.be.deep.equal([OPTIONAL]);
         });
 
         it("gives newly available packages when a dependency is completed ", async () => {

--- a/test/series.ts
+++ b/test/series.ts
@@ -1,7 +1,16 @@
 import { expect } from "chai";
-
 import { buildOrder } from "../lib/series";
-import { DEPENDENT, fileReader, IPackageName, mockPathSettings, SINGLE, SOLO } from "./fakes";
+import {
+    DEPENDENT,
+    DEV,
+    fileReader,
+    IPackageName,
+    mockPathSettings,
+    OPTIONAL,
+    PEER,
+    SINGLE,
+    SOLO,
+} from "./fakes";
 
 /**
  * Generates a build order from stubbed packages.
@@ -38,5 +47,29 @@ describe("buildOrder", () => {
 
         // Assert
         expect(order).to.be.deep.equal([SINGLE, DEPENDENT]);
+    });
+
+    it("returns packages in order when using dev dependencies", async () => {
+        // Act
+        const order = await mockBuildOrder(SINGLE, DEV, DEPENDENT);
+
+        // Assert
+        expect(order).to.be.deep.equal([SINGLE, DEV, DEPENDENT]);
+    });
+
+    it("returns packages in order when using peer dependencies", async () => {
+        // Act
+        const order = await mockBuildOrder(SINGLE, PEER, DEPENDENT);
+
+        // Assert
+        expect(order).to.be.deep.equal([SINGLE, PEER, DEPENDENT]);
+    });
+
+    it("returns packages in order when using optional dependencies", async () => {
+        // Act
+        const order = await mockBuildOrder(SINGLE, OPTIONAL, DEPENDENT);
+
+        // Assert
+        expect(order).to.be.deep.equal([SINGLE, OPTIONAL, DEPENDENT]);
     });
 });


### PR DESCRIPTION
The current library only supports calculating the build order using dependencies or devDependencies. This change adds support for peerDependencies and optionalDependencies.

For example:
- `app` has `libraryA` as a dependency
- `app` has `libraryB` as a dependency
- `libraryA` has `libraryB` as a peerDependency
- Therefore we need to build `libraryB` first before building `libraryA` or `app`

Fixes JoshuaKGoldberg/package-build-order#10